### PR TITLE
Adds ability to customize error messages at schema node level

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -1,5 +1,4 @@
-import toPath from "lodash.topath";
-import get from "lodash.get";
+import _ from "lodash";
 import Ajv from "ajv";
 const ajv = new Ajv({
   errorDataPath: "property",
@@ -39,7 +38,7 @@ function toErrorSchema(errors) {
   }
   return errors.reduce((errorSchema, error) => {
     const { property, message } = error;
-    const path = toPath(property);
+    const path = _.toPath(property);
     let parent = errorSchema;
 
     // If the property is at the root (.level1) then toPath creates
@@ -147,7 +146,7 @@ function transformAjvErrors(errors = [], schema) {
 
     const messagePath = getPathToMessages(schemaPath);
     const messagesObj = messagePath
-      ? get(schema, getPathToMessages(schemaPath))
+      ? _.get(schema, getPathToMessages(schemaPath))
       : undefined;
     const messageToDisplay = messagesObj ? messagesObj[keyword] : message;
 

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,4 +1,5 @@
 import toPath from "lodash.topath";
+import get from "lodash.get";
 import Ajv from "ajv";
 const ajv = new Ajv({
   errorDataPath: "property",
@@ -119,10 +120,14 @@ function unwrapErrorHandler(errorHandler) {
   }, {});
 }
 
-function getPathToMessages(path){
+function getPathToMessages(path) {
+  if (typeof path !== "string") {
+    return undefined;
+  }
+
   path = path.split("/").slice(1);
   path.pop();
-  path.push('messages');
+  path.push("messages");
 
   return path;
 }
@@ -140,7 +145,10 @@ function transformAjvErrors(errors = [], schema) {
     const { dataPath, keyword, message, params, schemaPath } = e;
     let property = `${dataPath}`;
 
-    const messagesObj = _.get(schema, getPathToMessages(schemaPath));
+    const messagePath = getPathToMessages(schemaPath);
+    const messagesObj = messagePath
+      ? get(schema, getPathToMessages(schemaPath))
+      : undefined;
     const messageToDisplay = messagesObj ? messagesObj[keyword] : message;
 
     // put data in expected format

--- a/src/validate.js
+++ b/src/validate.js
@@ -122,10 +122,9 @@ function unwrapErrorHandler(errorHandler) {
 function convertPath(path){
   var result = [];
   path.split("/").slice(1).forEach(function(elem){
-      if(elem == '#') {
-        continue;
+      if(elem !== '#') {
+        result.push(elem); 
       }
-      result.push(elem); 
   });
   return result;
 }

--- a/src/validate.js
+++ b/src/validate.js
@@ -120,18 +120,11 @@ function unwrapErrorHandler(errorHandler) {
 }
 
 function getPathToMessages(path){
-  var result = [];
+  path.split("/").slice(1);
+  path.pop();
+  path.push('messages');
 
-  path.split("/").slice(1).forEach(function(elem){
-      if(elem !== '#') {
-        result.push(elem); 
-      }
-  });
-
-  result.pop();
-  result.push('messages');
-
-  return result;
+  return path;
 }
 
 /**

--- a/src/validate.js
+++ b/src/validate.js
@@ -3,6 +3,7 @@ import Ajv from "ajv";
 const ajv = new Ajv({
   errorDataPath: "property",
   allErrors: true,
+  ownProperties: true,
   multipleOfPrecision: 8,
 });
 // add custom formats

--- a/src/validate.js
+++ b/src/validate.js
@@ -129,7 +129,7 @@ function transformAjvErrors(errors = []) {
   }
 
   return errors.map(e => {
-    const { dataPath, keyword, message, params } = e;
+    const { dataPath, keyword, message, params, schema } = e;
     let property = `${dataPath}`;
 
     // put data in expected format
@@ -138,6 +138,7 @@ function transformAjvErrors(errors = []) {
       property,
       message,
       params, // specific to ajv
+      schema,
       stack: `${property} ${message}`.trim(),
     };
   });

--- a/src/validate.js
+++ b/src/validate.js
@@ -126,7 +126,9 @@ function convertPath(path){
         result.push(elem); 
       }
   });
-  return result.pop().push('messages');
+  result.pop();
+  result.push('messages')
+  return result;
 }
 
 /**

--- a/src/validate.js
+++ b/src/validate.js
@@ -126,7 +126,7 @@ function convertPath(path){
         result.push(elem); 
       }
   });
-  return result;
+  return result.pop().push('messages');
 }
 
 /**
@@ -142,7 +142,7 @@ function transformAjvErrors(errors = [], schema) {
     const { dataPath, keyword, message, params, schemaPath } = e;
     let property = `${dataPath}`;
 
-    var messages = _.get(schema,convertPath(schemaPath));
+    var messages = _.get(schema.properties,convertPath(schemaPath));
     var customMessage = messages ? messages[keyword] : message;
 
 

--- a/src/validate.js
+++ b/src/validate.js
@@ -144,7 +144,7 @@ function transformAjvErrors(errors = [], schema) {
     const { dataPath, keyword, message, params, schemaPath } = e;
     let property = `${dataPath}`;
 
-    var messages = _.get(schema.properties,convertPath(schemaPath));
+    var messages = _.get(schema,convertPath(schemaPath));
     var customMessage = messages ? messages[keyword] : message;
 
 

--- a/src/validate.js
+++ b/src/validate.js
@@ -119,15 +119,18 @@ function unwrapErrorHandler(errorHandler) {
   }, {});
 }
 
-function convertPath(path){
+function getPathToMessages(path){
   var result = [];
+
   path.split("/").slice(1).forEach(function(elem){
       if(elem !== '#') {
         result.push(elem); 
       }
   });
+
   result.pop();
-  result.push('messages')
+  result.push('messages');
+
   return result;
 }
 
@@ -144,17 +147,15 @@ function transformAjvErrors(errors = [], schema) {
     const { dataPath, keyword, message, params, schemaPath } = e;
     let property = `${dataPath}`;
 
-    var messages = _.get(schema,convertPath(schemaPath));
-    var customMessage = messages ? messages[keyword] : message;
-
+    const messagesObj = _.get(schema, getPathToMessages(schemaPath));
+    const messageToDisplay = messagesObj ? messagesObj[keyword] : message;
 
     // put data in expected format
     return {
       name: keyword,
       property,
-      message: customMessage,
+      message: messageToDisplay,
       params, // specific to ajv
-      e,
       stack: `${property} ${message}`.trim(),
     };
   });

--- a/src/validate.js
+++ b/src/validate.js
@@ -129,7 +129,7 @@ function transformAjvErrors(errors = []) {
   }
 
   return errors.map(e => {
-    const { dataPath, keyword, message, params, schema } = e;
+    const { dataPath, keyword, message, params } = e;
     let property = `${dataPath}`;
 
     // put data in expected format
@@ -138,7 +138,7 @@ function transformAjvErrors(errors = []) {
       property,
       message,
       params, // specific to ajv
-      schema,
+      e,
       stack: `${property} ${message}`.trim(),
     };
   });

--- a/src/validate.js
+++ b/src/validate.js
@@ -120,7 +120,7 @@ function unwrapErrorHandler(errorHandler) {
 }
 
 function getPathToMessages(path){
-  path.split("/").slice(1);
+  path = path.split("/").slice(1);
   path.pop();
   path.push('messages');
 


### PR DESCRIPTION
E.g. 
`const schema = {
    type: 'object',
    required: ['firstName', 'lastName'],
    properties: {
        firstName: {
            type: 'string',
            title: 'First Name',
            minLength: 5,
            messages: {
                required: 'Please enter your First name',
                minLength: 'First name should be > 5 characters',
            },
        },
        lastName: {
            type: 'array',
            title: 'buncha strings',
            items: {
                description: '',
                minLength: 5,
                title: '',
                type: 'string',
                messages: {
                    required: 'Please enter your First name',
                    minLength: 'TOO SHORT',
                },
            },
        },
        abstract: {
            type: 'object',
            title: 'buncha strings',
            required: ['code'],
            properties: {
                code: {
                    type: 'string',
                    title: 'Code',
                },
                description: {
                    type: 'string',
                    title: 'Description',
                },
                name: {
                    type: 'string',
                    title: 'Field Name',
                    minLength: 5,
                    messages: {
                        minLength: 'Field Name is too short!',
                    },
                },
                required: {
                    default: false,
                    type: 'boolean',
                    title: 'Required?',
                },
            },
        },
    },
};`

This schema replaces the default error messages for `minLength` and `required` with customized messages. If customized messages are not provided, the default messages are shown.

Confirmed to work with fields nested in arrays and objects, and also with custom fields.